### PR TITLE
feat: Select sink by name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,11 +13,13 @@ import (
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeConfigPath, "kubeconfig", "", "Path to a kubeconfig file.")
+	rootCmd.PersistentFlags().StringVar(&sinkName, "sink", "null", "Sink that events should be pushed to.")
 }
 
 // CLI Flags
 var (
 	kubeConfigPath string
+	sinkName       string
 )
 
 var rootCmd = &cobra.Command{
@@ -33,7 +35,7 @@ var rootCmd = &cobra.Command{
 		}
 		cmd.SetContext(logger.ContextWithLogger(cmd.Context(), log))
 
-		sinker, err := sinker.NewSinker(cmd.Context(), kubeConfigPath)
+		sinker, err := sinker.NewSinker(cmd.Context(), kubeConfigPath, sinkName)
 		if err != nil {
 			panic(fmt.Errorf("failed to create new sinker: %v", err))
 		}

--- a/pkg/sinker/sinks/null.go
+++ b/pkg/sinker/sinks/null.go
@@ -1,0 +1,13 @@
+package sinks
+
+// NullSink is a sink that does nothing.
+type NullSink struct{}
+
+// OnAdd does nothing with an Add event.
+func (n *NullSink) OnAdd(obj interface{}) {}
+
+// OnUpdate does nothing with an Update event.
+func (n *NullSink) OnUpdate(oldObj, newObj interface{}) {}
+
+// OnDelete does nothing with a Delete event.
+func (n *NullSink) OnDelete(obj interface{}) {}

--- a/pkg/sinker/sinks/types.go
+++ b/pkg/sinker/sinks/types.go
@@ -1,0 +1,27 @@
+package sinks
+
+import "fmt"
+
+const (
+	nullSink string = "null"
+)
+
+// Sink handles events.
+// Handlers are informational only, they must not modify the event object.
+type Sink interface {
+	OnAdd(obj interface{})
+	OnUpdate(oldObj, newObj interface{})
+	OnDelete(obj interface{})
+}
+
+// NewSink returns the Sink corresponding to the provided sink name.
+func NewSink(name string) (Sink, error) {
+	// TODO: Metrics. The sink handlers should be wrapped.
+	// TODO: Should also skip events from before the application started.
+	switch name {
+	case nullSink:
+		return &NullSink{}, nil
+	default:
+		return nil, fmt.Errorf("unrecognised sink: %s", name)
+	}
+}


### PR DESCRIPTION
This PR:
- Add a CLI flag to select the sink to use.
- Replace the placeholder event handler with the handler from the selected sink.
- Default sink is a null sink that does nothing.