### PR TITLE
feat: Add zap logger sink

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -13,9 +13,9 @@ var KubernetesEvents = prometheus.NewCounterVec(
 		Help: "Total of Kubernetes events handled.",
 	},
 	[]string{
-		"regarding_kind",
-		"regarding_name",
-		"regarding_namespace",
+		"kind",
+		"name",
+		"namespace",
 		"reason",
 		"type",
 	},

--- a/pkg/sinker/sinker.go
+++ b/pkg/sinker/sinker.go
@@ -43,7 +43,7 @@ func NewSinker(ctx context.Context, kubeConfigPath, sinkName string) (*Sinker, e
 
 	// Select the Sink by name.
 	// All Sinks provide a handler for the events.
-	sink, err := sinks.NewSink(sinkName)
+	sink, err := sinks.NewSink(ctx, sinkName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sinker/sinks/metrics.go
+++ b/pkg/sinker/sinks/metrics.go
@@ -12,27 +12,27 @@ type MetricsSink struct{}
 
 // OnAdd handles Add events.
 func (m *MetricsSink) OnAdd(obj interface{}) {
-	m.generate(obj)
+	m.handle(obj)
 }
 
 // OnUpdate handles Update events.
 func (m *MetricsSink) OnUpdate(oldObj, newObj interface{}) {
-	m.generate(newObj)
+	m.handle(newObj)
 }
 
 // OnDelete handles Delete events.
 func (m *MetricsSink) OnDelete(obj interface{}) {
-	m.generate(obj)
+	m.handle(obj)
 }
 
-// generate generates prometheus metrics.
-func (m *MetricsSink) generate(obj interface{}) {
+// handle handles an event.
+func (m *MetricsSink) handle(obj interface{}) {
 	event := obj.(*eventsv1.Event)
 	metrics.KubernetesEvents.With(prometheus.Labels{
-		"regarding_kind":      event.Regarding.Kind,
-		"regarding_name":      event.Regarding.Name,
-		"regarding_namespace": event.Regarding.Namespace,
-		"reason":              event.Reason,
-		"type":                event.Type,
+		"kind":      event.Regarding.Kind,
+		"name":      event.Regarding.Name,
+		"namespace": event.Regarding.Namespace,
+		"reason":    event.Reason,
+		"type":      event.Type,
 	}).Inc()
 }

--- a/pkg/sinker/sinks/types.go
+++ b/pkg/sinker/sinks/types.go
@@ -1,9 +1,13 @@
 package sinks
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 const (
 	nullSinkName string = "null"
+	zapSinkName  string = "zap"
 )
 
 // Sink handles events.
@@ -15,12 +19,14 @@ type Sink interface {
 }
 
 // NewSink returns the Sink corresponding to the provided sink name.
-func NewSink(name string) (Sink, error) {
+func NewSink(ctx context.Context, name string) (Sink, error) {
 	// TODO: Should the metrics sink be a wrapper?
 	// TODO: Should also skip events from before the application started.
 	switch name {
 	case nullSinkName:
 		return &nullSink{}, nil
+	case zapSinkName:
+		return &zapSink{ctx: ctx}, nil
 	default:
 		return nil, fmt.Errorf("unrecognised sink: %s", name)
 	}

--- a/pkg/sinker/sinks/zap.go
+++ b/pkg/sinker/sinks/zap.go
@@ -1,0 +1,42 @@
+package sinks
+
+import (
+	"context"
+
+	"github.com/AyCarlito/kube-event-sinker/pkg/logger"
+	"go.uber.org/zap"
+	eventsv1 "k8s.io/api/events/v1"
+)
+
+// zapSink is a sink that records events through a zap logger.
+type zapSink struct {
+	ctx context.Context
+}
+
+// OnAdd handles Add events.
+func (z *zapSink) OnAdd(obj interface{}) {
+	z.handle(obj)
+}
+
+// OnUpdate handles Update events.
+func (z *zapSink) OnUpdate(oldObj, newObj interface{}) {
+	z.handle(newObj)
+}
+
+// OnDelete handles Delete events.
+func (z *zapSink) OnDelete(obj interface{}) {
+	z.handle(obj)
+}
+
+// handle handles an event.
+func (z *zapSink) handle(obj interface{}) {
+	event := obj.(*eventsv1.Event)
+	log := logger.LoggerFromContext(z.ctx).With(
+		zap.String("kind", event.Regarding.Kind),
+		zap.String("name", event.Regarding.Name),
+		zap.String("namespace", event.Regarding.Namespace),
+		zap.String("reason", event.Reason),
+		zap.String("type", event.Type),
+	)
+	log.Info("Handling")
+}


### PR DESCRIPTION
This PR:
- Add a sink that records events through a zap logger.
- This is the same zap logger used throughout the rest of the application code.
- Drop "regarding" prefix from the metric labels.