### PR TITLE
feat: Signal handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -59,20 +62,54 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		// By default, cobra prints the error and usage string on every error.
-		// We only desire this behaviour in the case where command line parsing fails e.g. unknown command or flag.
-		// Cobra does not provide a mechanism for achieving this fine grain control, so we implement our own.
-		if strings.Contains(err.Error(), "command") || strings.Contains(err.Error(), "flag") {
-			// Parsing errors are printed along with the usage string.
-			fmt.Println(err.Error())
-			fmt.Println(rootCmd.UsageString())
-		} else {
-			// Other errors logged, no usage string displayed.
-			log := logger.LoggerFromContext(rootCmd.Context())
-			log.Error(err.Error())
+	ctx, cxl := context.WithCancel(context.Background())
+	defer cxl()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	errChan := make(chan error)
+	go func(c chan<- error) {
+		c <- rootCmd.ExecuteContext(ctx)
+	}(errChan)
+
+	exitCode := 0
+	signalCaught := false
+
+outer:
+	for {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				exitCode = 1
+				// By default, cobra prints the error and usage string on every error.
+				// We only desire this behaviour in the case where command line parsing fails e.g. unknown command or flag.
+				// Cobra does not provide a mechanism for achieving this fine grain control, so we implement our own.
+				if strings.Contains(err.Error(), "command") || strings.Contains(err.Error(), "flag") {
+					// Parsing errors are printed along with the usage string.
+					fmt.Println(err.Error())
+					fmt.Println(rootCmd.UsageString())
+				} else {
+					// Other errors logged, no usage string displayed.
+					log := logger.LoggerFromContext(rootCmd.Context())
+					log.Error(err.Error())
+				}
+			}
+			break outer
+
+		case <-sigChan:
+			// Cancel context for graceful shutdown.
+			cxl()
+			exitCode = -1
+
+			// This check results in one of two desired behaviours:
+			// 1) Following a signal, we only exit after a subsequent signal.
+			// 2) Following a signal, we only exit after a notification on the error channel i.e. shutdown is complete.
+			if signalCaught {
+				break outer
+			}
+			signalCaught = true
 		}
-		os.Exit(1)
 	}
+	os.Exit(exitCode)
 }

--- a/pkg/sinker/sinker.go
+++ b/pkg/sinker/sinker.go
@@ -89,5 +89,18 @@ func (s *Sinker) Start() error {
 	}
 	log.Info("Cache synced")
 	<-s.ctx.Done()
+	s.shutdown()
 	return nil
+}
+
+// shutdown shuts down the Sinker.
+// It blocks until the underlying Informer has stopped.
+func (s *Sinker) shutdown() {
+	log := logger.LoggerFromContext(s.ctx)
+	log.Info("Shutting down sinker")
+	for {
+		if s.informer.Informer().IsStopped() {
+			return
+		}
+	}
 }

--- a/pkg/sinker/sinks/zap.go
+++ b/pkg/sinker/sinks/zap.go
@@ -3,9 +3,10 @@ package sinks
 import (
 	"context"
 
-	"github.com/AyCarlito/kube-event-sinker/pkg/logger"
 	"go.uber.org/zap"
 	eventsv1 "k8s.io/api/events/v1"
+
+	"github.com/AyCarlito/kube-event-sinker/pkg/logger"
 )
 
 // zapSink is a sink that records events through a zap logger.


### PR DESCRIPTION
This PR:
- Add signal handling to facilitate graceful shutdown. 
- When we receive a signal on a channel, cancel the context. This blocks until the Sinker (and consequently the underlying informer) have stopped. 