### PR TITLE
feat: Remove "name" label to reduce cardinality

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,7 +14,6 @@ var KubernetesEvents = prometheus.NewCounterVec(
 	},
 	[]string{
 		"kind",
-		"name",
 		"namespace",
 		"reason",
 		"type",

--- a/pkg/sinker/sinks/metrics.go
+++ b/pkg/sinker/sinks/metrics.go
@@ -36,7 +36,6 @@ func (m *metricsSink) handle(obj interface{}) {
 	event := obj.(*eventsv1.Event)
 	metrics.KubernetesEvents.With(prometheus.Labels{
 		"kind":      event.Regarding.Kind,
-		"name":      event.Regarding.Name,
 		"namespace": event.Regarding.Namespace,
 		"reason":    event.Reason,
 		"type":      event.Type,


### PR DESCRIPTION
This PR:
- Remove the "name" label from the "kube_event_sinker_events_total" counter metric to reduce cardinality. 