### PR TITLE
feat: Remove "namespace" label to reduce cardinality

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,7 +14,6 @@ var KubernetesEvents = prometheus.NewCounterVec(
 	},
 	[]string{
 		"kind",
-		"namespace",
 		"reason",
 		"type",
 	},

--- a/pkg/sinker/sinks/metrics.go
+++ b/pkg/sinker/sinks/metrics.go
@@ -35,10 +35,9 @@ func (m *metricsSink) OnDelete(obj interface{}) {
 func (m *metricsSink) handle(obj interface{}) {
 	event := obj.(*eventsv1.Event)
 	metrics.KubernetesEvents.With(prometheus.Labels{
-		"kind":      event.Regarding.Kind,
-		"namespace": event.Regarding.Namespace,
-		"reason":    event.Reason,
-		"type":      event.Type,
+		"kind":   event.Regarding.Kind,
+		"reason": event.Reason,
+		"type":   event.Type,
 	}).Inc()
 }
 


### PR DESCRIPTION
This PR:
- Remove the "namespace" label from the "kube_event_sinker_events_total" counter metric to reduce cardinality.